### PR TITLE
MQTT-Acknowledge Messages Timestamp Check Bugix

### DIFF
--- a/TxtFactoryClient/src/main.cpp
+++ b/TxtFactoryClient/src/main.cpp
@@ -98,7 +98,7 @@ class callback : public virtual mqtt::callback
 				std::string sts = root["ts"].asString();
 				SPDLOG_LOGGER_DEBUG(spdlog::get("console"), "  ts:{}", sts);
 
-				if (!ft::trycheckTimestampTTL(sts))
+				if (ft::trycheckTimestampTTL(sts))
 				{
 					mpo_.requestQuit();
 				}
@@ -153,7 +153,7 @@ class callback : public virtual mqtt::callback
 					default:
 						break;
 					}
-				}
+				}TOPIC_OUTPUT_STATE_ACK
 			} catch (const Json::RuntimeError& exc) {
 				std::cout << "Error: " << exc.what() << std::endl;
 			}
@@ -200,7 +200,7 @@ class callback : public virtual mqtt::callback
 				ssin >> root;
 				std::string sts = root["ts"].asString();
 				SPDLOG_LOGGER_DEBUG(spdlog::get("console"), "  ts:{}", sts);
-				if (!ft::trycheckTimestampTTL(sts))
+				if (ft::trycheckTimestampTTL(sts))
 				{
 					hbw_.requestQuit();
 				}
@@ -313,7 +313,7 @@ class callback : public virtual mqtt::callback
 				ssin >> root;
 				std::string sts = root["ts"].asString();
 				SPDLOG_LOGGER_DEBUG(spdlog::get("console"), "  ts:{}", sts);
-				if (!ft::trycheckTimestampTTL(sts))
+				if (ft::trycheckTimestampTTL(sts))
 				{
 					vgr_.requestQuit();
 				}
@@ -562,7 +562,7 @@ class callback : public virtual mqtt::callback
 				ssin >> root;
 				std::string sts = root["ts"].asString();
 				SPDLOG_LOGGER_DEBUG(spdlog::get("console"), "  ts:{}", sts);
-				if (!ft::trycheckTimestampTTL(sts))
+				if (ft::trycheckTimestampTTL(sts))
 				{
 					sld_.requestQuit();
 				}

--- a/TxtFactoryClient/src/main.cpp
+++ b/TxtFactoryClient/src/main.cpp
@@ -153,7 +153,7 @@ class callback : public virtual mqtt::callback
 					default:
 						break;
 					}
-				}TOPIC_OUTPUT_STATE_ACK
+				}
 			} catch (const Json::RuntimeError& exc) {
 				std::cout << "Error: " << exc.what() << std::endl;
 			}


### PR DESCRIPTION
Hallo Herr Steiger,

ich habe heute auf die neue Firmware (4.6.6) und die Txt-Version 0.8.0 gewechselt und es scheint als würde das Quittieren von Fehlern in der Cloud nicht funktionieren.

Es wird zwar der Timestamp über MQTT veröffentlicht, und der VGR bekommt auch die entsprechende MQTT-Nachricht, verwirft diese aber (!!!)

In TxtFactoryClient.cpp wird der Timestamp in der MQTT-JSON-Nachricht geprüft, ob dieser im 10-Sekunden Fenster liegt.
Allerdings wird der return der trycheckTimestampTTL negiert (!ft::trycheckTimestampTTL), das dürft meiner Meinung nach nicht sein.
Sonst müsste in der MQTT-Nachricht ein Timestamp angegeben werden der mindestens 10 Sekunden von der aktuellen Zeit abweicht.

Dies sind die entsprechenden Code-Stellen.
Utils.cpp (ft::trycheckTimestampTTL)
https://github.com/fischertechnik/txt_training_factory/blob/master/TxtSmartFactoryLib/src/Utils.cpp#L64

TxtFactoryClient
https://github.com/fischertechnik/txt_training_factory/blob/master/TxtFactoryClient/src/main.cpp#L316


Mein Test Setup:
-	Werkstück in SLD einlegen und nach der Farberkennung entfernen.
-	VGR fährt zur Abholposition
-	NFC wird geprüft  Error
-	VGR befindet sich in Error-State
-	Über Fischertechnik-Cloud Dashboard/MQTT-Nachricht (Topic f/o/state/ack) Nachricht veröffentlichen
o	mosquitto_pub -u txt -P xtx -t f/o/state/ack -m "{\"ts\": \"$(date -u +'%Y-%m-%dT%H:%M:%S').00Z\"}" -h 192.168.0.10
-	VGR erhält Nachricht, Timestamp wird validiert (erfolgreich) -> Negierung in IF-Statement
-	VGR bleibt im Error-State

Freundliche Grüße,
Mark-Oliver
