### PR TITLE
Publish HBW stored acks

### DIFF
--- a/TxtSmartFactoryLib/src/TxtHighBayWarehouseRun.cpp
+++ b/TxtSmartFactoryLib/src/TxtHighBayWarehouseRun.cpp
@@ -168,6 +168,9 @@ void TxtHighBayWarehouse::fsmStep()
 		{
 			if (reqVGRwp && store(*reqVGRwp))
 			{
+				assert(mqttclient);
+				mqttclient->publishHBW_Ack(HBW_STORED, reqVGRwp, TIMEOUT_MS_PUBLISH);
+
 				FSM_TRANSITION( IDLE, color=green, label='workpiece\nstored' );
 			}
 			else
@@ -220,6 +223,9 @@ void TxtHighBayWarehouse::fsmStep()
 		printState(STORE_CONTAINER);
 		if (storeContainer())
 		{
+			assert(mqttclient);
+			mqttclient->publishHBW_Ack(HBW_STORED, 0, TIMEOUT_MS_PUBLISH);
+
 			FSM_TRANSITION( IDLE, color=green, label='container\nstored' );
 		}
 		else


### PR DESCRIPTION
Publish the missing `HBW_STORED` acknowledgments as specified by the [MQTT interface documentation](https://github.com/fischertechnik/txt_training_factory/blob/master/TxtSmartFactoryLib/doc/MqttInterface.md#txtfactoryhbw).


